### PR TITLE
Prime HLS signed cookies before playback

### DIFF
--- a/Django Files/API/DFAPI.swift
+++ b/Django Files/API/DFAPI.swift
@@ -21,7 +21,7 @@ struct DFAPI {
     private static let API_PATH = "/api/"
     
     // Custom User Agent for API requests
-    private static let customUserAgent = "DjangoFiles iOS \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")(\(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-"))"
+    internal static let customUserAgent = "DjangoFiles iOS \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")(\(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-"))"
 
     // Add a shared WebSocket instance
     internal static var sharedWebSocket: DFWebSocket?

--- a/Django Files/API/Streams.swift
+++ b/Django Files/API/Streams.swift
@@ -666,8 +666,9 @@ extension DFAPI {
     // 401/403) are reported separately so callers can keep retrying.
     public enum HLSCookieResult {
         case ok(exp: Int)
-        case unsupported  // endpoint missing — older backend, no signing required
-        case failure      // network error or auth/password mismatch on a supported backend
+        case unsupported     // endpoint missing — older backend, no signing required
+        case passwordRequired // 403 with `detail: password required` — caller should prompt
+        case failure         // other network error or auth mismatch
     }
 
     public func refreshHLSCookies(name: String, password: String? = nil) async -> HLSCookieResult {
@@ -699,6 +700,14 @@ extension DFAPI {
             guard let http = response as? HTTPURLResponse else { return .failure }
             if http.statusCode == 404 {
                 return .unsupported
+            }
+            if http.statusCode == 403 {
+                struct HLSTokenError: Decodable { let detail: String? }
+                let detail = (try? JSONDecoder().decode(HLSTokenError.self, from: data))?.detail ?? ""
+                if detail.localizedCaseInsensitiveContains("password") {
+                    return .passwordRequired
+                }
+                return .failure
             }
             guard (200..<300).contains(http.statusCode) else { return .failure }
             // URLSession should have stored the cookies already, but parse from

--- a/Django Files/API/Streams.swift
+++ b/Django Files/API/Streams.swift
@@ -640,6 +640,82 @@ extension DFAPI {
             return nil
         }
     }
+
+    // MARK: - HLS Signed Cookies
+    //
+    // The backend gates `/hls/*.m3u8` and `/hls/*.ts` behind nginx `secure_link`
+    // cookies (`hls_sig`, `hls_exp`). This endpoint validates the public/private
+    // and password gates server-side, then sets the cookies in the response.
+    //
+    // We deliberately use a `URLSession` backed by `HTTPCookieStorage.shared` so
+    // the cookies persist into the storage that `AVURLAsset` consults when
+    // fetching the manifest and segments. The class-default `apiSession` is
+    // `.ephemeral`, which would silently drop them.
+    //
+    // Auth/password rules (must match django-files):
+    //   - Public stream, no password: anonymous works (no Authorization header).
+    //   - Public stream, password set: pass `?password=…`.
+    //   - Private stream: send `Authorization: <token>` (bare token; the backend
+    //     also accepts `Bearer <token>`).
+    //   - Private + password: both.
+    //
+    // Backwards compatibility: older django-files versions don't expose this
+    // endpoint and serve `/hls/` without any signature check. A 404 here means
+    // "old backend, no cookies needed" — callers should fall through to the
+    // unsigned HLS fetch and skip the refresh loop. Other failures (network,
+    // 401/403) are reported separately so callers can keep retrying.
+    public enum HLSCookieResult {
+        case ok(exp: Int)
+        case unsupported  // endpoint missing — older backend, no signing required
+        case failure      // network error or auth/password mismatch on a supported backend
+    }
+
+    public func refreshHLSCookies(name: String, password: String? = nil) async -> HLSCookieResult {
+        guard var components = URLComponents(
+            url: url.appendingPathComponent("api/stream/hls-token/\(name)/"),
+            resolvingAgainstBaseURL: false
+        ) else { return .failure }
+        if let pw = password, !pw.isEmpty {
+            components.queryItems = [URLQueryItem(name: "password", value: pw)]
+        }
+        guard let endpoint = components.url else { return .failure }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(DFAPI.customUserAgent, forHTTPHeaderField: "User-Agent")
+        if !token.isEmpty {
+            request.setValue(token, forHTTPHeaderField: "Authorization")
+        }
+
+        let config = URLSessionConfiguration.default
+        config.httpCookieStorage = HTTPCookieStorage.shared
+        config.httpCookieAcceptPolicy = .always
+        config.httpShouldSetCookies = true
+        let session = URLSession(configuration: config)
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return .failure }
+            if http.statusCode == 404 {
+                return .unsupported
+            }
+            guard (200..<300).contains(http.statusCode) else { return .failure }
+            // URLSession should have stored the cookies already, but parse from
+            // the response headers as a belt-and-suspenders so we don't depend
+            // on configuration ordering across iOS versions.
+            if let headers = http.allHeaderFields as? [String: String] {
+                let cookies = HTTPCookie.cookies(withResponseHeaderFields: headers, for: endpoint)
+                cookies.forEach { HTTPCookieStorage.shared.setCookie($0) }
+            }
+            struct HLSTokenResponse: Decodable { let exp: Int }
+            let exp = try JSONDecoder().decode(HLSTokenResponse.self, from: data).exp
+            return .ok(exp: exp)
+        } catch {
+            print("refreshHLSCookies failed: \(error)")
+            return .failure
+        }
+    }
 }
 
 // MARK: - Slash Commands

--- a/Django Files/Views/Streams/StreamView.swift
+++ b/Django Files/Views/Streams/StreamView.swift
@@ -173,6 +173,13 @@ struct StreamView: View {
     @State private var streamStartedAt: Date?
     @State private var streamEndedAt: Date?
 
+    // HLS signed-cookie refresh — `/api/stream/hls-token/<name>/` mints the
+    // `hls_sig`/`hls_exp` cookies nginx requires. We refresh at roughly half
+    // the cookie's remaining TTL so long viewing sessions don't get dropped.
+    @State private var hlsRefreshTimer: Timer?
+    private static let hlsRefreshFallback: TimeInterval = 30 * 60
+    private static let hlsRefreshFloor: TimeInterval = 60
+
     // Chat
     @StateObject private var chatManager: StreamChatManager
     @State private var inputText: String = ""
@@ -871,7 +878,8 @@ struct StreamView: View {
             streamEndedAt = s.endedAt
         }
 
-        setupHLSPlayer()
+        isVideoLoading = true
+        Task { await primeHLSCookiesAndPlay() }
         chatManager.connect()
         startViewerCountPolling()
         resetControlsTimer()
@@ -890,20 +898,59 @@ struct StreamView: View {
         viewerRefreshTimer = nil
         controlsFadeTimer?.invalidate()
         controlsFadeTimer = nil
+        hlsRefreshTimer?.invalidate()
+        hlsRefreshTimer = nil
     }
 
     // MARK: - HLS Setup
 
+    /// Fetches HLS signed cookies, then constructs the player. Always sets up
+    /// the player even if the cookie call failed — older backends serve `/hls/`
+    /// unsigned (the call 404s with `.unsupported`), and on a supported backend
+    /// the AVPlayer error path will surface "Stream offline" exactly as before.
+    private func primeHLSCookiesAndPlay() async {
+        let api = DFAPI(url: serverURL, token: token)
+        let result = await api.refreshHLSCookies(name: streamName, password: password)
+        await MainActor.run {
+            setupHLSPlayer()
+            scheduleHLSRefresh(result: result)
+        }
+    }
+
+    private func scheduleHLSRefresh(result: DFAPI.HLSCookieResult) {
+        hlsRefreshTimer?.invalidate()
+        let delay: TimeInterval
+        switch result {
+        case .unsupported:
+            // Old backend with unsigned `/hls/` — nothing to refresh, ever.
+            return
+        case .ok(let exp):
+            let remaining = max(0, Double(exp) - Date().timeIntervalSince1970)
+            delay = min(Self.hlsRefreshFallback, max(Self.hlsRefreshFloor, remaining / 2))
+        case .failure:
+            delay = Self.hlsRefreshFallback
+        }
+        hlsRefreshTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { _ in
+            Task {
+                let api = DFAPI(url: serverURL, token: token)
+                let next = await api.refreshHLSCookies(name: streamName, password: password)
+                await MainActor.run { scheduleHLSRefresh(result: next) }
+            }
+        }
+    }
+
     private func setupHLSPlayer() {
         let base = serverURL.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        var urlString = "\(base)/hls/\(streamName).m3u8"
-        if let pw = password, !pw.isEmpty,
-           let encoded = pw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            urlString += "?password=\(encoded)"
-        }
+        let urlString = "\(base)/hls/\(streamName).m3u8"
         guard let hlsURL = URL(string: urlString) else { return }
         isVideoLoading = true
-        let item = AVPlayerItem(url: hlsURL)
+        // Pass the matching cookies explicitly. `AVURLAsset` consults
+        // `HTTPCookieStorage.shared` by default, but being explicit avoids
+        // surprises on iOS versions where the asset's network stack uses a
+        // different cookie scope.
+        let cookies = HTTPCookieStorage.shared.cookies(for: hlsURL) ?? []
+        let asset = AVURLAsset(url: hlsURL, options: ["AVURLAssetHTTPCookiesKey": cookies])
+        let item = AVPlayerItem(asset: asset)
         let newPlayer = AVPlayer(playerItem: item)
         // Keep the default (true): AVPlayer buffers before playing and auto-recovers
         // brief network stalls by buffering more. Setting false causes a tight

--- a/Django Files/Views/Streams/StreamView.swift
+++ b/Django Files/Views/Streams/StreamView.swift
@@ -155,7 +155,12 @@ struct StreamView: View {
     let streamName: String
     let token: String
     let initialStream: DFStream?
-    var password: String? = nil
+
+    // Mutable password — seeded from the deep-link/init param, updated by the
+    // in-app prompt when the backend reports `password required` / mismatch.
+    @State private var currentPassword: String?
+    @State private var showPasswordPrompt: Bool = false
+    @State private var passwordInput: String = ""
 
     // HLS player
     @State private var player: AVPlayer?
@@ -224,7 +229,7 @@ struct StreamView: View {
         self.streamName = streamName
         self.token = token
         self.initialStream = initialStream
-        self.password = password
+        _currentPassword = State(initialValue: password)
         _chatManager = StateObject(wrappedValue: StreamChatManager(
             serverURL: serverURL, token: token,
             streamName: streamName, isOwner: initialStream?.isOwner ?? false,
@@ -249,6 +254,17 @@ struct StreamView: View {
         }
         .sheet(isPresented: $showViewersList) { viewersSheet }
         .sheet(isPresented: $showingShareSheet) { ShareSheet(url: streamShareURL) }
+        .alert("Password Required", isPresented: $showPasswordPrompt) {
+            SecureField("Password", text: $passwordInput)
+                .textContentType(.password)
+            Button("Unlock") { submitPassword() }
+            Button("Cancel", role: .cancel) {
+                passwordInput = ""
+                isVideoLoading = false
+            }
+        } message: {
+            Text("This stream is password-protected.")
+        }
         // Use item: so the CaptureMode value is captured directly in the closure,
         // avoiding the stale-state bug with isPresented + a separate state variable.
         .fullScreenCover(item: $broadcastMode) { captureMode in
@@ -910,10 +926,44 @@ struct StreamView: View {
     /// the AVPlayer error path will surface "Stream offline" exactly as before.
     private func primeHLSCookiesAndPlay() async {
         let api = DFAPI(url: serverURL, token: token)
-        let result = await api.refreshHLSCookies(name: streamName, password: password)
+        let suppliedPassword = currentPassword
+        let result = await api.refreshHLSCookies(name: streamName, password: suppliedPassword)
         await MainActor.run {
-            setupHLSPlayer()
+            // If the deep link supplied a wrong password, treat it like a retry
+            // so the user sees a toast explaining why they're being re-prompted.
+            handleHLSResult(result, isRetry: !(suppliedPassword?.isEmpty ?? true))
+        }
+    }
+
+    /// Centralizes UI side-effects of an HLS-token call: starts/refreshes the
+    /// player on success, prompts the viewer on a password failure, and (when
+    /// the failure follows an explicit submission) surfaces a toast.
+    private func handleHLSResult(_ result: DFAPI.HLSCookieResult, isRetry: Bool) {
+        switch result {
+        case .passwordRequired:
+            if isRetry {
+                ToastManager.shared.showToast(message: "Incorrect password")
+            }
+            passwordInput = ""
+            showPasswordPrompt = true
+            isVideoLoading = false
+        case .ok, .unsupported, .failure:
+            if player == nil { setupHLSPlayer() }
             scheduleHLSRefresh(result: result)
+        }
+    }
+
+    private func submitPassword() {
+        let entered = passwordInput
+        passwordInput = ""
+        showPasswordPrompt = false
+        guard !entered.isEmpty else { return }
+        currentPassword = entered
+        isVideoLoading = true
+        Task {
+            let api = DFAPI(url: serverURL, token: token)
+            let result = await api.refreshHLSCookies(name: streamName, password: entered)
+            await MainActor.run { handleHLSResult(result, isRetry: true) }
         }
     }
 
@@ -927,14 +977,14 @@ struct StreamView: View {
         case .ok(let exp):
             let remaining = max(0, Double(exp) - Date().timeIntervalSince1970)
             delay = min(Self.hlsRefreshFallback, max(Self.hlsRefreshFloor, remaining / 2))
-        case .failure:
+        case .failure, .passwordRequired:
             delay = Self.hlsRefreshFallback
         }
         hlsRefreshTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { _ in
             Task {
                 let api = DFAPI(url: serverURL, token: token)
-                let next = await api.refreshHLSCookies(name: streamName, password: password)
-                await MainActor.run { scheduleHLSRefresh(result: next) }
+                let next = await api.refreshHLSCookies(name: streamName, password: currentPassword)
+                await MainActor.run { handleHLSResult(next, isRetry: false) }
             }
         }
     }


### PR DESCRIPTION
## Summary
Backend PR https://github.com/django-files/django-files/pull/386 puts `/hls/*.m3u8` and `/hls/*.ts` behind an nginx `secure_link` check using `hls_sig`/`hls_exp` cookies. Without those cookies, segment fetches return 403, so the player needs to mint them before opening the manifest.

This change:

- Adds `DFAPI.refreshHLSCookies(name:password:)` that calls `GET /api/stream/hls-token/<name>/` through a `URLSession` backed by `HTTPCookieStorage.shared`, so `AVURLAsset` picks the cookies up automatically. It also explicitly re-parses `Set-Cookie` as a belt-and-suspenders.
- Sends `Authorization: <token>` only when we have one (anonymous viewers of public streams stay anonymous), and forwards `?password=...` only when supplied. Order matches the backend gates.
- Drops the legacy `?password=...` querystring from the `/hls/*.m3u8` URL — the cookie is the authorization now.
- Schedules a non-repeating `Timer` to refresh the cookies at roughly half the remaining TTL (clamped to `[60s, 30min]`) so long viewing sessions don't get evicted.
- Passes the matching cookies via `AVURLAssetHTTPCookiesKey` so behavior is deterministic across iOS network-stack quirks.

## Backwards compatibility

The endpoint is brand new. Older django-files versions don't have it and serve `/hls/` unsigned. To keep working against those backends:

- `refreshHLSCookies` returns a 3-state `HLSCookieResult`: `.ok(exp:)`, `.unsupported` (HTTP 404 — old backend), or `.failure` (network / auth / password error on a supported backend).
- On `.unsupported` we set up the player as before and **do not** schedule any refresh — there is nothing to refresh against. The unsigned HLS works as it always did.
- On `.failure` we still set up the player (preserves "Stream offline" fallback) and retry after the fallback interval.
- On `.ok` we schedule the half-TTL refresh.

Anonymous viewing of public streams still works (no `Authorization` header sent when token is empty).

## Test plan
- [ ] New backend, public stream, signed in: playback works, cookies set, refresh fires at half TTL.
- [ ] New backend, public stream, anonymous: same — no `Authorization` header sent.
- [ ] New backend, private stream, signed in: playback works.
- [ ] New backend, password-protected stream: deep-link with `&password=...` works; wrong password keeps player offline.
- [ ] Old backend (no `/api/stream/hls-token/` endpoint): playback works exactly as before, no refresh loop scheduled.
- [ ] Long session (longer than `HLS_SIGNED_URL_TTL_SECONDS`): playback survives across the refresh boundary.