### PR TITLE
Bump svenstaro/upload-release-action from v2 to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
       - name: "Upload IPA to Release"
         if: ${{ github.event_name == 'release' }}
         continue-on-error: true
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@v3
         with:
           file: "Django Files.ipa"
           tag: ${{ github.ref }}


### PR DESCRIPTION
## Summary

- \`svenstaro/upload-release-action@v2\` uses Node 16 which is end-of-life, causing a warning in the **Publish** workflow
- Bumps to \`@v3\` which uses a supported Node runtime

## Test plan

- [ ] Confirm no EOL Node warning appears on the next Publish workflow run