### PR TITLE
Add album selection to share sheet extension

### DIFF
--- a/Django Files/API/DFAPI.swift
+++ b/Django Files/API/DFAPI.swift
@@ -230,11 +230,14 @@ struct DFAPI {
         }
     }
 
-    public func uploadFileStreamed(url: URL, fileName: String? = nil, privateUpload: Bool = false, stripExif: Bool = false, stripGps: Bool = false, taskDelegate: URLSessionTaskDelegate) async -> DjangoFilesUploadDelegate? {
+    public func uploadFileStreamed(url: URL, fileName: String? = nil, albums: String = "", privateUpload: Bool = false, stripExif: Bool = false, stripGps: Bool = false, taskDelegate: URLSessionTaskDelegate) async -> DjangoFilesUploadDelegate? {
         let boundary = UUID().uuidString
 
         do {
             var headers: [HTTPField.Name: String] = [.contentType: "multipart/form-data; boundary=\(boundary)"]
+            if !albums.isEmpty {
+                headers[HTTPField.Name("Albums")!] = albums
+            }
             if privateUpload {
                 headers[HTTPField.Name("Private")!] = "true"
             }

--- a/UploadAndCopy/ShareView.swift
+++ b/UploadAndCopy/ShareView.swift
@@ -112,6 +112,37 @@ struct ShareView: View {
             }
             .padding(.top, 8)
 
+            if !viewModel.showShortText {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Album")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 16)
+
+                    Button {
+                        viewModel.showAlbumPicker = true
+                    } label: {
+                        HStack {
+                            Text(viewModel.selectedAlbumIDs.isEmpty ? "None" : "\(viewModel.selectedAlbumIDs.count) selected")
+                                .lineLimit(1)
+                                .foregroundColor(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color(.systemGray5))
+                        .cornerRadius(8)
+                    }
+                    .disabled(viewModel.selectedSession == nil)
+                    .padding(.horizontal, 16)
+                }
+                .padding(.top, 8)
+            }
+
             VStack(spacing: 2) {
                 Toggle("Private", isOn: $viewModel.privateUpload)
                     .padding(.horizontal, 16)
@@ -157,6 +188,9 @@ struct ShareView: View {
                     .scaleEffect(1.5)
             }
         }
+        .sheet(isPresented: $viewModel.showAlbumPicker) {
+            ShareAlbumPickerSheet(server: viewModel.selectedSession, selectedAlbumIDs: $viewModel.selectedAlbumIDs)
+        }
         .toastNotification(
             message: viewModel.alertMessage,
             isPresented: $viewModel.showAlert,
@@ -196,6 +230,8 @@ class ShareViewModel: ObservableObject {
     @Published var stripExif: Bool = false
     @Published var stripGps: Bool = false
     @Published var isImageUpload: Bool = false
+    @Published var selectedAlbumIDs: [Int] = []
+    @Published var showAlbumPicker: Bool = false
 
     weak var shareViewController: ShareViewController?
     

--- a/UploadAndCopy/ShareViewController.swift
+++ b/UploadAndCopy/ShareViewController.swift
@@ -347,8 +347,10 @@ class ShareViewController: UIViewController, URLSessionTaskDelegate {
         let api = DFAPI(url: URL(string: session.url)!, token: session.token)
         let total = shareURLs.count
 
+        let albums = viewModel.selectedAlbumIDs.map(String.init).joined(separator: ",")
+
         for (index, url) in shareURLs.enumerated() {
-            let task = await api.uploadFileStreamed(url: url, privateUpload: viewModel.privateUpload, stripExif: viewModel.stripExif, stripGps: viewModel.stripGps, taskDelegate: self)
+            let task = await api.uploadFileStreamed(url: url, albums: albums, privateUpload: viewModel.privateUpload, stripExif: viewModel.stripExif, stripGps: viewModel.stripGps, taskDelegate: self)
             let response = await task?.waitForComplete()
 
             if let responseURL = response?.url {


### PR DESCRIPTION
## Summary

- Adds an **Album** picker section to the share sheet UI, matching the album selection already available in the in-app upload flow
- Uses the existing `ShareAlbumPickerSheet` (which supports browsing, searching, and creating albums) — it was already in the target but not wired up
- Album picker is hidden when sharing a URL for shortening (albums don't apply there)
- Adds `albums` parameter to `uploadFileStreamed` in `DFAPI` so selected album IDs are sent as the `Albums` header on upload

## Test plan

- [ ] Share an image/file from another app → confirm Album row appears in the share sheet
- [ ] Tap Album → sheet opens, can browse/search/select albums
- [ ] Upload with an album selected → verify file appears in that album on the server
- [ ] Share a URL (link shortening) → confirm Album row is hidden
- [ ] Share with no album selected → upload succeeds as before