### PR TITLE
Show tags on file info page

### DIFF
--- a/Django Files/Views/Preview/Info.swift
+++ b/Django Files/Views/Preview/Info.swift
@@ -265,6 +265,30 @@ struct PreviewFileInfo: View {
                 }
             }
 
+            // Tags Section
+            if !file.tags.isEmpty {
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("Tags", systemImage: "tag")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(file.tags, id: \.self) { tag in
+                                Text(tag)
+                                    .font(.caption)
+                                    .lineLimit(1)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 5)
+                                    .background(.tint.opacity(0.12), in: Capsule())
+                                    .foregroundStyle(.tint)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+
             // Albums Section
             if !file.albums.isEmpty {
                 Divider()


### PR DESCRIPTION
## Summary

- Adds a Tags section to `PreviewFileInfo` (`Views/Preview/Info.swift`), displayed between the GPS/map section and the Albums section
- Renders each tag as a horizontal-scrolling capsule pill, identical in style to the existing Albums chips (`background(.tint.opacity(0.12), in: Capsule())`)
- No async fetch required — tags are already decoded as `[String]` on `DFFile`, unlike albums which are `[Int]` IDs that need a separate API call
- Section is hidden when `file.tags` is empty, matching albums behaviour

## Test plan

- [ ] Open a file that has one or more tags — Tags section appears above Albums with capsule pills
- [ ] Open a file with no tags — Tags section is absent
- [ ] Tags with long names truncate to one line and the row scrolls horizontally
- [ ] Tint colour applies correctly in both light and dark mode